### PR TITLE
Fix #311: resolve log path against filteredRuns to support local time mode

### DIFF
--- a/robotframework_dashboard/js/log.js
+++ b/robotframework_dashboard/js/log.js
@@ -25,7 +25,14 @@ function open_log_file(event, chartElement, callbackData = undefined, directRunS
         const index = chartElement[0].index
         runStart = event.chart.data.labels[index]
     }
-    var output = runs.find(run => run.run_start.slice(0, 19) === runStart.slice(0, 19))
+    // Match against filteredRuns: its run_start has been timezone-converted/stripped to
+    // match what the chart actually displays. Falling back to the original `runs` global
+    // (UTC strings) breaks when the user has the "convert to local timezone" toggle on,
+    // since the chart label no longer equals the UTC run_start. See issue #311.
+    var output = filteredRuns.find(run => run.run_start.slice(0, 19) === runStart.slice(0, 19))
+    if (!output) { output = filteredRuns.find(run => get_run_label(run) === runStart) }
+    // Fallback to the raw runs array for safety (e.g. if the run was filtered out)
+    if (!output) { output = runs.find(run => run.run_start.slice(0, 19) === runStart.slice(0, 19)) }
     if (!output) { output = runs.find(run => get_run_label(run) === runStart) }
     var path = output ? output.path : ""
     if (path == "") {

--- a/tests/javascript/log.test.js
+++ b/tests/javascript/log.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mutable mock state for runs/filteredRuns so individual tests can set them up.
+const dataMock = {
+    runs: [],
+    suites: [],
+    tests: [],
+    server: false,
+    use_logs: true,
+};
+const globalsMock = {
+    filteredRuns: [],
+    filteredSuites: [],
+    filteredTests: [],
+    filteredKeywords: [],
+};
+
+vi.mock('@js/variables/data.js', () => dataMock);
+vi.mock('@js/variables/globals.js', () => globalsMock);
+vi.mock('@js/variables/settings.js', () => ({
+    settings: { show: { aliases: 'run_start' } },
+    get_run_label: (item) => item.run_start,
+}));
+
+// log.js calls window.open and alert; stub them.
+beforeEach(() => {
+    dataMock.runs.length = 0;
+    dataMock.suites.length = 0;
+    dataMock.tests.length = 0;
+    globalsMock.filteredRuns.length = 0;
+    globalsMock.filteredSuites.length = 0;
+    globalsMock.filteredTests.length = 0;
+    globalsMock.filteredKeywords.length = 0;
+    globalThis.window = { open: vi.fn(() => ({})), location: { href: 'http://localhost/' } };
+    globalThis.alert = vi.fn();
+});
+
+const { open_log_file } = await import('@js/log.js');
+
+// Build a fake chart click event for a non-line, non-doughnut graph that
+// reads chart.data.labels[index]. Matches the path log.js takes for e.g.
+// the bar statistics graph (the one in the issue's repro).
+function makeBarClickEvent(label, graphId = 'runStatisticsGraph') {
+    return {
+        chart: {
+            config: { _config: { type: 'bar' } },
+            canvas: { id: graphId },
+            data: { labels: [label] },
+        },
+    };
+}
+
+describe('open_log_file (issue #311)', () => {
+    it('resolves log path against filteredRuns when timezone is converted to local time', () => {
+        // The DB / unfiltered runs hold the original UTC run_start.
+        const utcStart = '2025-01-15 10:00:00';
+        // After the "convert to local timezone" toggle, filteredRuns carries
+        // the local-time wall-clock string — this is what the chart label shows.
+        const localStart = '2025-01-15 12:00:00';
+        const path = '/results/output.xml';
+
+        dataMock.runs.push({ run_start: utcStart, path, run_alias: null });
+        globalsMock.filteredRuns.push({ run_start: localStart, path, run_alias: null });
+
+        const event = makeBarClickEvent(localStart);
+        const chartElement = [{ index: 0 }];
+
+        open_log_file(event, chartElement);
+
+        // Before the fix: lookup happened against `runs` (UTC), no match, alert fired.
+        expect(globalThis.alert).not.toHaveBeenCalled();
+        expect(globalThis.window.open).toHaveBeenCalledTimes(1);
+        const openedUrl = globalThis.window.open.mock.calls[0][0];
+        // output.xml is rewritten to log.html by transform_file_path
+        expect(openedUrl).toContain('log.html');
+    });
+
+    it('still resolves correctly in UTC mode (filteredRuns == runs run_start)', () => {
+        const utcStart = '2025-01-15 10:00:00';
+        const path = '/results/output.xml';
+        dataMock.runs.push({ run_start: utcStart, path, run_alias: null });
+        globalsMock.filteredRuns.push({ run_start: utcStart, path, run_alias: null });
+
+        const event = makeBarClickEvent(utcStart);
+        open_log_file(event, [{ index: 0 }]);
+
+        expect(globalThis.alert).not.toHaveBeenCalled();
+        expect(globalThis.window.open).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to raw runs when the clicked run was filtered out', () => {
+        const utcStart = '2025-01-15 10:00:00';
+        const path = '/results/output.xml';
+        dataMock.runs.push({ run_start: utcStart, path, run_alias: null });
+        // filteredRuns is empty — run filtered away
+
+        const event = makeBarClickEvent(utcStart);
+        open_log_file(event, [{ index: 0 }]);
+
+        expect(globalThis.alert).not.toHaveBeenCalled();
+        expect(globalThis.window.open).toHaveBeenCalledTimes(1);
+    });
+
+    it('alerts only when no matching run exists anywhere', () => {
+        const event = makeBarClickEvent('2099-12-31 00:00:00');
+        open_log_file(event, [{ index: 0 }]);
+        expect(globalThis.alert).toHaveBeenCalledTimes(1);
+        expect(globalThis.window.open).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #311.

## Problem

When the "convert to local timezone" toggle is on, clicking a run on any chart shows:

> Log file error: this output didn't have a path in the database so the log file cannot be found!

…even though `path` is non-empty in the DB and `log.html` exists on disk.

## Root cause

In `js/log.js` `open_log_file`, the lookup compared the clicked label against the raw `runs` global:

```js
var output = runs.find(run => run.run_start.slice(0, 19) === runStart.slice(0, 19))
```

But `runs[i].run_start` holds the **original UTC** string from the DB, while chart labels (and the clicked value) come from `filteredRuns`, whose `run_start` has been rewritten by `convert_timezone` / `remove_timezones` in `filter.js` to match the displayed local time. The substring compare never matches → `output = undefined` → `path = ""` → alert.

## Fix

Look up against `filteredRuns` first (whose `run_start` mirrors what the chart actually shows), then fall back to the raw `runs` array so filtered-out runs still resolve. The downstream `update_log_path_with_id` path keeps using raw `runs`/`suites`/`tests` — they share the original UTC timestamps internally so suite/test id lookup remains consistent.

## Evidence

Added `tests/javascript/log.test.js` with 4 cases. Reverting just `log.js` while keeping the new test reproduces the issue's exact alert text:

```
FAIL  tests/javascript/log.test.js > open_log_file (issue #311) > resolves log path against filteredRuns when timezone is converted to local time
  Received:
    1st vi.fn() call: [ "Log file error: this output didn't have a path in the database so the log file cannot be found!" ]
```

With the fix applied:

```
✓ resolves log path against filteredRuns when timezone is converted to local time
✓ still resolves correctly in UTC mode (filteredRuns == runs run_start)
✓ falls back to raw runs when the clicked run was filtered out
✓ alerts only when no matching run exists anywhere

Test Files  12 passed (12)
Tests       232 passed (232)
```

Full JS suite (`npm run test:js`) green — no regressions.

---

## Acceptance Criteria

- [x] `open_log_file` resolves log path against `filteredRuns` when timezone is converted to local time
- [x] Still resolves correctly in UTC mode (`filteredRuns == runs`)
- [x] Falls back to raw `runs` when clicked run was filtered out
- [x] Alerts only when no matching run exists anywhere
- [x] All 232 JS tests pass with no regressions
- [x] Python and Robot Framework tests pass
- [ ] Code review approved by a maintainer
