### PR TITLE
Pr/apply filter in overview

### DIFF
--- a/robotframework_dashboard/js/eventlisteners.js
+++ b/robotframework_dashboard/js/eventlisteners.js
@@ -326,6 +326,7 @@ function setup_filter_modal() {
                 add_alert(`Filter profile "${name}" applied`, "success");
                 update_profile_select_display();
                 populate_filter_profile_select();
+                update_filters_button_indicator();
             }
         }
     });

--- a/robotframework_dashboard/js/eventlisteners.js
+++ b/robotframework_dashboard/js/eventlisteners.js
@@ -28,7 +28,6 @@ import {
     setup_project_versions_in_select_filter_buttons,
     setup_suite_path_navigator,
     setup_custom_filters_in_select_filter_buttons,
-    update_overview_version_select_list,
     setup_metadata_filter,
     build_profile_from_checks,
     apply_filter_profile,
@@ -59,6 +58,8 @@ import {
     set_filter_show_current_project,
     set_filter_show_current_version,
     update_overview_filter_visibility,
+    update_duration_comparison_for_all_projects,
+    update_overview_version_select_list,
 } from "./graph_creation/overview.js";
 import { update_run_donut_total_graph, update_run_heatmap_graph } from "./graph_creation/run.js";
 import {
@@ -402,6 +403,11 @@ function setup_filter_modal() {
         add_alert(`Filter profile "${newName}" saved!`, "success");
         bootstrap.Modal.getInstance(document.getElementById("mergeProfilesModal")).hide();
     });
+    // Show indicator dot when a specific run is selected in the dropdown
+    document.getElementById("runs").addEventListener("change", function () {
+        const indicator = document.getElementById("filterRunSelectedIndicator");
+        if (indicator) indicator.style.display = this.value !== "All" ? "inline-block" : "none";
+    });
     // Listen for filter changes to update the profile display
     const filterModal = document.getElementById("filtersModal");
     filterModal.addEventListener("change", function () {
@@ -500,10 +506,14 @@ function setup_settings_modal() {
         { key: "show.convertTimezone", elementId: "toggleTimezone" },
         { key: "show.suitesSelectionInSuiteStats", elementId: "toggleSuitesSelectionInSuiteStats", datatype: "string", event: "change" },
         { key: "show.suitesSelectionInTestStats", elementId: "toggleSuitesSelectionInTestStats", datatype: "string", event: "change" },
+        { key: "show.overviewDurationPercentage", elementId: "overviewDurationPercentage", datatype: "number", event: "change" },
     ].forEach(def => {
         const handler = create_toggle_handler(def);
         handler(true);
         document.getElementById(def.elementId).addEventListener(def.event || "click", () => handler());
+    });
+    document.getElementById("overviewDurationPercentage").addEventListener("change", () => {
+        if (settings.menu.overview) update_duration_comparison_for_all_projects();
     });
     // Re-populate the date filter pickers when either timezone toggle changes,
     // since the displayed timestamps change and the defaults need to match.
@@ -757,7 +767,6 @@ function setup_sections_filters() {
     update_switch_local_storage("switch.runName", settings.switch.runName, true);
     update_switch_local_storage("switch.totalStats", settings.switch.totalStats, true);
     update_switch_local_storage("switch.latestRuns", settings.switch.latestRuns, true);
-    update_switch_local_storage("switch.percentageFilters", settings.switch.percentageFilters, true);
     update_switch_local_storage("switch.versionFilters", settings.switch.versionFilters, true);
     update_switch_local_storage("switch.sortFilters", settings.switch.sortFilters, true);
     document.getElementById("switchRunTags").addEventListener("click", function () {
@@ -808,19 +817,14 @@ function setup_sections_filters() {
         update_switch_local_storage("switch.totalStats", settings.switch.totalStats);
         update_overview_sections_visibility();
     });
-    document.getElementById("switchPercentageFilters").addEventListener("click", function () {
-        settings.switch.percentageFilters = !settings.switch.percentageFilters
-        update_switch_local_storage("switch.percentageFilters", settings.switch.percentageFilters);
+    document.getElementById("switchVersionFilters").addEventListener("click", function () {
+        settings.switch.versionFilters = !settings.switch.versionFilters
+        update_switch_local_storage("switch.versionFilters", settings.switch.versionFilters);
         update_overview_filter_visibility();
     });
     document.getElementById("switchSortFilters").addEventListener("click", function () {
         settings.switch.sortFilters = !settings.switch.sortFilters
         update_switch_local_storage("switch.sortFilters", settings.switch.sortFilters);
-        update_overview_filter_visibility();
-    });
-    document.getElementById("switchVersionFilters").addEventListener("click", function () {
-        settings.switch.versionFilters = !settings.switch.versionFilters
-        update_switch_local_storage("switch.versionFilters", settings.switch.versionFilters);
         update_overview_filter_visibility();
     });
     document.getElementById("suiteSelectSuites").addEventListener("change", () => {

--- a/robotframework_dashboard/js/eventlisteners.js
+++ b/robotframework_dashboard/js/eventlisteners.js
@@ -159,6 +159,14 @@ function update_merge_result_preview() {
 
 // ---- end of merge profiles helpers ----
 
+function update_filters_button_indicator() {
+    const indicator = document.getElementById("filtersActiveIndicator");
+    if (!indicator) return;
+    const anyActive = [...document.querySelectorAll("#filtersModal .version-selected-dot")]
+        .some(el => el.style.display !== "none");
+    indicator.style.display = anyActive ? "inline-block" : "none";
+}
+
 // function to setup filter modal eventlisteners
 function setup_filter_modal() {
     // eventlistener to catch the closing of the filter modal
@@ -407,14 +415,17 @@ function setup_filter_modal() {
     document.getElementById("runs").addEventListener("change", function () {
         const indicator = document.getElementById("filterRunSelectedIndicator");
         if (indicator) indicator.style.display = this.value !== "All" ? "inline-block" : "none";
+        update_filters_button_indicator();
     });
-    // Listen for filter changes to update the profile display
+    // Listen for filter changes to update the profile display and the navbar dot
     const filterModal = document.getElementById("filtersModal");
     filterModal.addEventListener("change", function () {
         update_profile_select_display();
+        update_filters_button_indicator();
     });
     filterModal.addEventListener("input", function () {
         update_profile_select_display();
+        update_filters_button_indicator();
     });
 }
 

--- a/robotframework_dashboard/js/filter.js
+++ b/robotframework_dashboard/js/filter.js
@@ -983,6 +983,8 @@ function clear_all_filters() {
     setup_lowest_highest_dates();
     const runsIndicator = document.getElementById("filterRunSelectedIndicator");
     if (runsIndicator) runsIndicator.style.display = "none";
+    const filtersActiveIndicator = document.getElementById("filtersActiveIndicator");
+    if (filtersActiveIndicator) filtersActiveIndicator.style.display = "none";
 }
 
 function clear_suite_path_filter() {

--- a/robotframework_dashboard/js/filter.js
+++ b/robotframework_dashboard/js/filter.js
@@ -902,69 +902,6 @@ function unselect_checkboxes(checkBoxesToUnselect) {
     }
 }
 
-function handle_overview_latest_version_selection(overviewVersionSelectorList, latestRunByProject) {
-    show_loading_overlay();
-    requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-            const selectedOptions = Array.from(
-                overviewVersionSelectorList.querySelectorAll("input:checked")
-            ).map(inputElement => inputElement.value);
-            if (selectedOptions.includes("All")) {
-                create_overview_latest_graphs(latestRunByProject);
-            } else {
-                const filteredLatestRunByProject = Object.fromEntries(
-                    Object.entries(latestRunByProject)
-                        .filter(([projectName, run]) => selectedOptions.includes(run.project_version ?? "None"))
-                );
-                create_overview_latest_graphs(filteredLatestRunByProject);
-            }
-            update_overview_latest_heading();
-            hide_loading_overlay();
-        });
-    });
-}
-
-// this function updates the version select list in the latest runs bar
-function update_overview_version_select_list() {
-    const overviewLatestVersionSelectorList = document.getElementById("overviewLatestVersionSelectorList");
-    if (overviewLatestVersionSelectorList) {
-        overviewLatestVersionSelectorList.innerHTML = '';
-        if (settings.switch.runName || settings.switch.runTags) {
-            const filteredLatestRunByProject = {};
-            settings.switch.runName && Object.assign(filteredLatestRunByProject, latestRunByProjectName);
-            settings.switch.runTags && Object.assign(filteredLatestRunByProject, latestRunByProjectTag);
-            const runAmountByVersion = {};
-            for (const run of Object.values(filteredLatestRunByProject)) {
-                const projectVersion = run.project_version ?? "None";
-                runAmountByVersion[projectVersion] ??= 0;
-                runAmountByVersion[projectVersion]++;
-            }
-            const allVersionAmountInFilter = Object.keys(runAmountByVersion).length;
-            const versionFilterListItemAllHtml = generate_version_filter_list_item_html("All", "overviewLatest", "checked", allVersionAmountInFilter, "version");
-            const specificVersionFilterListItemHtml = Object.keys(runAmountByVersion)
-                .sort()
-                .reverse()
-                .map(version => {
-                    return generate_version_filter_list_item_html(
-                        version,
-                        "overviewLatest",
-                        "", //not checked
-                        runAmountByVersion[version],
-                        "run"
-                    )
-                }).join('');
-            overviewLatestVersionSelectorList.innerHTML = versionFilterListItemAllHtml + specificVersionFilterListItemHtml;
-            const allCheckBox = document.getElementById("overviewLatestVersionFilterListItemAllInput");
-            setup_filter_checkbox_handler_listeners(
-                overviewLatestVersionSelectorList,
-                allCheckBox,
-                "overviewLatestVersionSelectedIndicator",
-                () => { handle_overview_latest_version_selection(overviewLatestVersionSelectorList, filteredLatestRunByProject) }
-            );
-        }
-    }
-}
-
 // for runTag/version filter popup and overview
 function setup_filter_checkbox_handler_listeners(
     checkBoxContainerElement,
@@ -1044,6 +981,8 @@ function clear_all_filters() {
     document.getElementById("amount").value = filteredAmountDefault;
     document.getElementById("metadata").value = "All";
     setup_lowest_highest_dates();
+    const runsIndicator = document.getElementById("filterRunSelectedIndicator");
+    if (runsIndicator) runsIndicator.style.display = "none";
 }
 
 function clear_suite_path_filter() {
@@ -1383,6 +1322,11 @@ function apply_filter_profile(profile, name) {
             if (modeEl) modeEl.value = mode;
         }
     }
+    const runsIndicator = document.getElementById("filterRunSelectedIndicator");
+    const runsVal = document.getElementById("runs")?.value;
+    if (runsIndicator)
+        runsIndicator.style.display =
+            runsVal && runsVal !== "All" ? "inline-block" : "none";
 }
 
 // Load filter profiles from settings (cumulative — never deletes existing ones)
@@ -1608,7 +1552,6 @@ export {
     setup_suite_path_navigator,
     setup_custom_filters_in_select_filter_buttons,
     setup_filter_checkbox_handler_listeners,
-    update_overview_version_select_list,
     clear_all_filters,
     set_filter_show_current_version,
     generate_version_filter_list_item_html,

--- a/robotframework_dashboard/js/graph_creation/all.js
+++ b/robotframework_dashboard/js/graph_creation/all.js
@@ -1,9 +1,10 @@
 import { settings } from "../variables/settings.js";
 
-import { 
+import {
     create_overview_latest_graphs,
     create_overview_total_graphs,
-    update_donut_charts
+    update_donut_charts,
+    update_grouped_data_for_filter
 } from "./overview.js";
 import {
     create_run_statistics_graph,
@@ -102,6 +103,7 @@ import { update_custom_stat_widgets } from "../statwidgets.js";
 // function that creates all graphs from scratch - used on first load of each tab
 function create_dashboard_graphs() {
     if (settings.menu.overview) {
+        update_grouped_data_for_filter();
         create_overview_latest_graphs();
         create_overview_total_graphs();
         update_donut_charts();
@@ -156,6 +158,7 @@ function create_dashboard_graphs() {
 // each update function falls back to create if the chart doesn't exist yet
 function update_dashboard_graphs() {
     if (settings.menu.overview) {
+        update_grouped_data_for_filter();
         create_overview_latest_graphs();
         create_overview_total_graphs();
         update_donut_charts();

--- a/robotframework_dashboard/js/graph_creation/overview.js
+++ b/robotframework_dashboard/js/graph_creation/overview.js
@@ -23,7 +23,6 @@ import {
 } from '../variables/chartconfig.js';
 import { settings } from '../variables/settings.js';
 import {
-    DEFAULT_DURATION_PERCENTAGE,
     projects_by_tag,
     projects_by_name,
     selectedRunSetting,
@@ -31,7 +30,8 @@ import {
     versionsByProject,
     latestRunByProjectName,
     latestRunByProjectTag,
-    areGroupedProjectsPrepared
+    areGroupedProjectsPrepared,
+    filteredRuns,
 } from '../variables/globals.js';
 import { runs, use_logs } from '../variables/data.js';
 import {
@@ -43,7 +43,7 @@ import {
 
 // Data prep/aggregation
 function prepare_projects_grouped_data() {
-    for (const run of runs) {
+    for (const run of filteredRuns) {
         const tags = run.tags.split(",");
         const project_tags = tags.filter(tag => tag.toLowerCase().startsWith("project_"));
         for (const project of project_tags) {
@@ -60,11 +60,11 @@ function prepare_projects_grouped_data() {
     areGroupedProjectsPrepared = true;
 }
 
-// versionByProject = {projectName:{version:amount}}
+// versionsByProject = {projectName: {version: amount}}
 function prepare_projects_version_counts_map(projects) {
-    for (const [project, runs] of Object.entries(projects)) {
+    for (const [project, projectRuns] of Object.entries(projects)) {
         const versionCounts = {};
-        for (const run of runs) {
+        for (const run of projectRuns) {
             const projectVersion = run.project_version ?? "None";
             versionCounts[projectVersion] = (versionCounts[projectVersion] || 0) + 1;
         }
@@ -154,12 +154,15 @@ function generate_overview_card_html(
         compares = '';
     }
     // for project bars
-    const versionsForProject = Object.keys(versionsByProject[projectName]);
-    const projectHasVersions = !(versionsForProject.length === 1 && versionsForProject[0] === "None");
+    const runsForProject = projects_by_name[projectName] ?? projects_by_tag[projectName] ?? [];
+    const projectHasVersions = runsForProject.some(r => r.project_version != null && r.project_version !== "None");
     // for overview statistics
     // Preserve the original project name (used for logic like tag-detection),
     // but compute a display name that omits the 'project_' prefix when prefixes are hidden.
     const originalProjectName = projectName;
+    const projectEverHasVersions = runs
+        .filter(r => r.name === originalProjectName)
+        .some(r => r.project_version != null && r.project_version !== "None");
     const displayProjectName = settings.show.prefixes ? projectName : projectName.replace(/^project_/, '');
     projectName = displayProjectName;
     let cardTitle = `
@@ -172,7 +175,7 @@ function generate_overview_card_html(
             cardTitle = `
                 <h5 class="card-title mb-0 fw-semibold">${stats[5]}, <span class="text-muted">Version:</span> ${normalizedProjectVersion}</h5>
             `;
-        } else if (projectHasVersions) {
+        } else if (projectHasVersions || projectEverHasVersions) {
             // Non-tagged projects with versions: interactive version title
             cardTitle = `
                 <div class="mx-auto run-card-version-title"
@@ -285,23 +288,62 @@ function _update_overview_heading(containerId, titleId, titleText) {
     if (subTitleEl) subTitleEl.innerHTML = `showing ${amountOfProjectsShown} project${pluralPostFix}`;
 }
 
-// create overview latest runs section dynamically
-function create_overview_latest_runs_section() {
-    const percentageSelectHtml = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map(val =>
-        `<option value="${val}" ${val === DEFAULT_DURATION_PERCENTAGE ? 'selected' : ''}>${val}</option>`
-    ).join('');
+function handle_overview_latest_version_selection(overviewVersionSelectorList, latestRunByProject) {
+    show_loading_overlay();
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            const selectedOptions = Array.from(
+                overviewVersionSelectorList.querySelectorAll("input:checked")
+            ).map(inputElement => inputElement.value);
+            if (selectedOptions.includes("All")) {
+                create_overview_latest_graphs(latestRunByProject);
+            } else {
+                const filteredLatestRunByProject = Object.fromEntries(
+                    Object.entries(latestRunByProject)
+                        .filter(([, run]) => selectedOptions.includes(run.project_version ?? "None"))
+                );
+                create_overview_latest_graphs(filteredLatestRunByProject);
+            }
+            update_overview_latest_heading();
+            hide_loading_overlay();
+        });
+    });
+}
 
+function update_overview_version_select_list() {
+    const overviewLatestVersionSelectorList = document.getElementById("overviewLatestVersionSelectorList");
+    if (overviewLatestVersionSelectorList) {
+        overviewLatestVersionSelectorList.innerHTML = '';
+        if (settings.switch.runName || settings.switch.runTags) {
+            const filteredLatestRunByProject = {};
+            settings.switch.runName && Object.assign(filteredLatestRunByProject, latestRunByProjectName);
+            settings.switch.runTags && Object.assign(filteredLatestRunByProject, latestRunByProjectTag);
+            const runAmountByVersion = {};
+            for (const run of Object.values(filteredLatestRunByProject)) {
+                const projectVersion = run.project_version ?? "None";
+                runAmountByVersion[projectVersion] ??= 0;
+                runAmountByVersion[projectVersion]++;
+            }
+            const allVersionAmountInFilter = Object.keys(runAmountByVersion).length;
+            const versionFilterListItemAllHtml = generate_version_filter_list_item_html("All", "overviewLatest", "checked", allVersionAmountInFilter, "version");
+            const specificVersionFilterListItemHtml = Object.keys(runAmountByVersion)
+                .sort().reverse()
+                .map(version => generate_version_filter_list_item_html(version, "overviewLatest", "", runAmountByVersion[version], "run"))
+                .join('');
+            overviewLatestVersionSelectorList.innerHTML = versionFilterListItemAllHtml + specificVersionFilterListItemHtml;
+            const allCheckBox = document.getElementById("overviewLatestVersionFilterListItemAllInput");
+            setup_filter_checkbox_handler_listeners(
+                overviewLatestVersionSelectorList,
+                allCheckBox,
+                "overviewLatestVersionSelectedIndicator",
+                () => { handle_overview_latest_version_selection(overviewLatestVersionSelectorList, filteredLatestRunByProject) }
+            );
+        }
+    }
+}
+
+function create_overview_latest_runs_section() {
     const filtersHtml = `
-        <div class="col-auto percentage-filter" id="overviewLatestPercentageFilterContainer">
-            <div class="btn-group">
-                <label class="form-check-label information info-label" for="overviewLatestDurationPercentage" id="overviewLatestPercentageInfo">Percentage <span class="info-icon-small ms-1"></span></label>
-            </div>
-            <div class="btn-group">
-                <select class="form-select form-select-sm me-2" id="overviewLatestDurationPercentage">
-                    ${percentageSelectHtml}
-                </select>
-            </div>
-        </div>
         <div class="col-auto me-2 version-filter" id="overviewLatestVersionFilterContainer">
             <div class="btn-group">
                 <label class="form-label mb-0 information info-label" id="overviewLatestVersionsInfo">Versions <span class="info-icon-small ms-1"></span></label>
@@ -347,29 +389,13 @@ function create_overview_latest_runs_section() {
 
     create_overview_latest_graphs();
     update_overview_latest_heading();
-
-    // Setup event listeners for filters
-    const percentageSelector = document.getElementById("overviewLatestDurationPercentage");
-    if (percentageSelector) {
-        percentageSelector.addEventListener('change', () => {
-            show_loading_overlay();
-            requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
-                    create_overview_latest_graphs();
-                    hide_loading_overlay();
-                });
-            });
-        });
-    }
+    update_overview_version_select_list();
 
     const versionFilterSearch = document.getElementById("overviewLatestVersionFilterSearch");
     if (versionFilterSearch) {
-        const handle_version_filter_input = () => {
-            apply_overview_latest_version_text_filter();
-        };
         const maxDelay = 50;
-        const delayScaledByRunAmount = Math.min(runs.length / 100, maxDelay);
-        versionFilterSearch.addEventListener('input', debounce(handle_version_filter_input, delayScaledByRunAmount));
+        const delayScaledByRunAmount = Math.min(filteredRuns.length / 100, maxDelay);
+        versionFilterSearch.addEventListener('input', debounce(apply_overview_latest_version_text_filter, delayScaledByRunAmount));
     }
 }
 
@@ -388,7 +414,7 @@ function create_overview_total_stats_section() {
 // create project bar (the collapsables below overview statistic) in overview
 function create_project_bar(projectName, projectRuns, totalRunsAmount, passRate) {
     const projectVersions = new Set(
-        Object.keys(versionsByProject[projectName])
+        Object.keys(versionsByProject[projectName] || {})
             .sort()
             .reverse()
     );
@@ -401,9 +427,6 @@ function create_project_bar(projectName, projectRuns, totalRunsAmount, passRate)
                 return generate_version_filter_list_item_html(version, projectName, "", runAmount, "run");
             })
             .join('');
-    const percentageSelectHtml = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map(val =>
-        `<option value="${val}" ${val === DEFAULT_DURATION_PERCENTAGE ? 'selected' : ''}>${val}</option>`
-    ).join('');
     // added here instead of adding to informationMap, since the dynamic IDs don't work with the map
     const displayProjectName = (!settings.show.prefixes && projectName.startsWith('project_'))
         ? projectName.replace(/^project_/, '')
@@ -430,27 +453,17 @@ See Settings > Overview for more options.`;
                         <h6>Total Runs: ${totalRunsAmount} | Passed Runs: ${passRate}%</h6>
                     </div>
                     <div class="d-flex flex-wrap align-items-start col align-items-center">
-                         <div class="col-auto me-2 percentage-filter">
-                            <div class="btn-group">
-                                <label class="form-check-label information info-label" for="${projectName}DurationPercentage" data-title="Duration color threshold: green if the run is at least X% faster than average, red if X% slower.">Percentage <span class="info-icon-small ms-1"></span></label>
-                            </div>
-                            <div class="btn-group">
-                                <select class="form-select form-select-sm" id="${projectName}DurationPercentage">
-                                    ${percentageSelectHtml}
-                                </select>
-                            </div>
-                        </div>
                         <div class="col-auto me-2 version-filter">
                             <div class="btn-group">
                                 <label class="form-label mb-0 information info-label" data-title="Filter runs by version. 'All' shows all versions.">Versions <span class="info-icon-small ms-1"></span></label>
                             </div>
                             <div class="btn-group">
-                                <div id="${projectName}VersionFilterDropDown" class="dropdown" >
+                                <div id="${projectName}VersionFilterDropDown" class="dropdown">
                                     <button class="btn btn-sm btn-outline-dark dropdown-toggle"
                                             type="button" id="${projectName}VersionFilterBtn"
                                             data-bs-toggle="dropdown" data-bs-auto-close="outside">
                                         Select Versions
-                                    <span id="${projectName}VersionSelectedIndicator" class="version-selected-dot" style="display:none;"></span>
+                                        <span id="${projectName}VersionSelectedIndicator" class="version-selected-dot" style="display:none;"></span>
                                     </button>
                                     <ul class="dropdown-menu p-3" style="max-height: 50vh; overflow-y: auto;">
                                         ${versionFilterListItemsHtml}
@@ -490,14 +503,7 @@ See Settings > Overview for more options.`;
     const overview = document.getElementById("overview")
     overview.appendChild(document.createRange().createContextualFragment(projectCard));
 
-    // percentage selector
-    const projectPercentageSelector = document.getElementById(`${projectName}DurationPercentage`);
-    projectPercentageSelector.addEventListener('change', () => {
-        const newPercent = parseInt(projectPercentageSelector.value, 10);
-        update_duration_comparison_for_project(projectName, projectRuns, newPercent);
-    });
-
-    // version filters
+    // version filter dropdown
     const versionFilterDropDownId = `${projectName}VersionFilterDropDown`;
     const versionFilterSearchId = `${projectName}VersionFilterSearch`;
     const versionFilterArgs = {
@@ -547,10 +553,8 @@ function create_project_cards_container(projectName, projectRuns, percent = null
     // create section for project in overview if not present
     if (!cardsContainer) create_project_bar(projectName, projectRuns, totalRunsAmount, passRate);
 
-    // Read percentage from selector if not provided
     if (percent === null) {
-        const percentageSelector = document.getElementById(`${projectName}DurationPercentage`);
-        percent = percentageSelector ? parseInt(percentageSelector.value, 10) : DEFAULT_DURATION_PERCENTAGE;
+        percent = settings.show.overviewDurationPercentage;
     }
 
     const container = document.getElementById(`${projectName}RunCardsContainer`);
@@ -607,7 +611,7 @@ function create_overview_latest_graphs(preFilteredRuns = null) {
             Object.entries(latestRunByProject).sort(([, runA], [, runB]) => runB.passed - runA.passed)
         );
     }
-    const percent = document.getElementById("overviewLatestDurationPercentage").value;
+    const percent = settings.show.overviewDurationPercentage;
     for (const [projectName, latestRun] of Object.entries(latestRunByProject)) {
         const projectRuns = allProjects[projectName];
         const totalRunsAmount = projectRuns.length;
@@ -628,7 +632,7 @@ function create_overview_latest_graphs(preFilteredRuns = null) {
             'overviewLatest'
         );
     }
-    apply_overview_latest_version_text_filter();
+    update_overview_latest_heading();
 }
 
 // function to create overview total statistics
@@ -842,14 +846,8 @@ function update_overview_sections_visibility() {
 }
 
 function update_overview_filter_visibility() {
-    // Update filter visibility for all bars using classes
-    const percentageFilters = document.querySelectorAll(".percentage-filter");
     const versionFilters = document.querySelectorAll(".version-filter");
     const sortFilters = document.querySelectorAll(".sort-filter");
-
-    percentageFilters.forEach(container => {
-        container.hidden = !settings.switch.percentageFilters;
-    });
     versionFilters.forEach(container => {
         container.hidden = !settings.switch.versionFilters;
     });
@@ -862,6 +860,46 @@ function update_donut_charts() {
     document.querySelectorAll(".overview-canvas").forEach(canvas => {
         const chart = canvas.querySelector("canvas").chartInstance;
         if (chart) chart.update();
+    });
+}
+
+// Updates project bars in-place after a filter change — avoids recreating Chart.js canvases.
+function update_grouped_data_for_filter() {
+    Object.keys(projects_by_tag).forEach(k => delete projects_by_tag[k]);
+    Object.keys(projects_by_name).forEach(k => delete projects_by_name[k]);
+    Object.keys(latestRunByProjectTag).forEach(k => delete latestRunByProjectTag[k]);
+    Object.keys(latestRunByProjectName).forEach(k => delete latestRunByProjectName[k]);
+    Object.keys(versionsByProject).forEach(k => delete versionsByProject[k]);
+    prepare_projects_grouped_data();
+    prepare_latest_run_by_project();
+    prepare_projects_version_counts_map({ ...projects_by_name, ...projects_by_tag });
+    const projectData = { ...projects_by_name, ...projects_by_tag };
+    document.querySelectorAll(".overview-project-card").forEach(bar => {
+        const projectName = bar.id.replace(/Section$/, "");
+        const projectRuns = projectData[projectName];
+        const isTagged = projectName.startsWith("project_");
+        const settingsVisible = isTagged ? settings.switch.runTags : settings.switch.runName;
+        bar.hidden = !settingsVisible || !projectRuns;
+        if (projectRuns && settingsVisible) {
+            const subtitleEl = bar.querySelector(".card-header h6");
+            if (subtitleEl) {
+                const totalRunsAmount = projectRuns.length;
+                const passedRunsAmount = projectRuns.filter(run => run.failed === 0).length;
+                const passRate = ((passedRunsAmount / totalRunsAmount) * 100).toFixed(2);
+                subtitleEl.textContent = `Total Runs: ${totalRunsAmount} | Passed Runs: ${passRate}%`;
+            }
+            create_project_cards_container(projectName, projectRuns);
+        }
+    });
+    update_overview_version_select_list();
+}
+
+function update_duration_comparison_for_all_projects() {
+    const percent = settings.show.overviewDurationPercentage;
+    document.querySelectorAll(".overview-project-card").forEach(bar => {
+        const projectName = bar.id.replace(/Section$/, "");
+        const projectRuns = projects_by_name[projectName] ?? projects_by_tag[projectName];
+        if (projectRuns) update_duration_comparison_for_project(projectName, projectRuns, percent);
     });
 }
 
@@ -960,5 +998,8 @@ export {
     update_overview_latest_heading,
     update_overview_total_heading,
     update_overview_sections_visibility,
-    update_overview_filter_visibility
+    update_overview_filter_visibility,
+    update_grouped_data_for_filter,
+    update_duration_comparison_for_all_projects,
+    update_overview_version_select_list,
 };

--- a/robotframework_dashboard/js/menu.js
+++ b/robotframework_dashboard/js/menu.js
@@ -1,4 +1,4 @@
-import { setup_filtered_data_and_filters, update_overview_version_select_list } from "./filter.js";
+import { setup_filtered_data_and_filters } from "./filter.js";
 import { areGroupedProjectsPrepared, overviewNavStore } from "./variables/globals.js";
 import { space_to_camelcase } from "./common.js";
 import { set_local_storage_item, setup_overview_localstorage } from "./localstorage.js";
@@ -80,7 +80,6 @@ function update_menu(item) {
         set_local_storage_item(`menu.${menuItem}`, (item === id));
         document.getElementById(id).classList.toggle("active", id === item);
     });
-    document.getElementById("filters").hidden = (item === "menuOverview");
     setup_data_and_graphs(true, item === "menuOverview" && !areGroupedProjectsPrepared);
 }
 
@@ -138,14 +137,13 @@ function setup_data_and_graphs(menuUpdate = false, prepareOverviewProjectData = 
     setup_spinner(false); // show spinner immediately
     requestAnimationFrame(() => {
         requestAnimationFrame(() => {
+            setup_filtered_data_and_filters();
             if (prepareOverviewProjectData) {
                 prepare_overview();
                 setup_overview_localstorage();
                 setup_overview_section_layout_buttons();
                 setup_overview_order_filters();
-                update_overview_version_select_list();
             }
-            setup_filtered_data_and_filters();
             setup_section_order();
             setup_graph_order();
             setup_information_popups();

--- a/robotframework_dashboard/js/variables/globals.js
+++ b/robotframework_dashboard/js/variables/globals.js
@@ -1,6 +1,5 @@
 // UI defaults
 const CARDS_PER_ROW = 3;
-const DEFAULT_DURATION_PERCENTAGE = 20;
 
 // populated by prepare_overview()
 const projects_by_tag = {};
@@ -147,7 +146,6 @@ var defaultFaviconHref = (() => {
 
 export {
     CARDS_PER_ROW,
-    DEFAULT_DURATION_PERCENTAGE,
     projects_by_tag,
     projects_by_name,
     latestRunByProjectTag,

--- a/robotframework_dashboard/js/variables/information.js
+++ b/robotframework_dashboard/js/variables/information.js
@@ -186,7 +186,7 @@ Tip: avoid using Status and Only Changes together — the result will be empty.`
     "settingProjectsByName": "Group and display projects on the Overview by their Robot Framework run name.",
     "settingProjectsByTag": "Group and display projects on the Overview by custom project_ tags. See the docs for project tagging.",
     "settingPrefixes": "Show or hide the 'project_' prefix on tag-based project names on the Overview.",
-    "settingPercentageFilters": "Show the duration percentage threshold filter used to color-code run durations on the Overview.",
+    "settingOverviewDurationPercentage": "Threshold for duration color comparison on all project bars. A run is green if at least X% faster than average, red if X% slower.",
     "settingVersionFilters": "Show the version filter for per-project version selection on the Overview.",
     "settingSortFilters": "Show the sort controls for ordering Overview project bars.",
     "settingBackgroundColor": "Main page background color for the current theme.",

--- a/robotframework_dashboard/js/variables/settings.js
+++ b/robotframework_dashboard/js/variables/settings.js
@@ -18,7 +18,6 @@ var settings = {
         runName: true,
         totalStats: true,
         latestRuns: true,
-        percentageFilters: true,
         versionFilters: true,
         sortFilters: true,
         suitePathsSuiteSection: false,
@@ -43,6 +42,7 @@ var settings = {
         compareStatusFilter: "All",
     },
     show: {
+        overviewDurationPercentage: 20,
         unified: false,
         dateLabels: true,
         legends: true,

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -56,8 +56,10 @@
             </li>
         </ul>
         <ul class="navbar-nav flex-row flex-nowrap ms-md-auto me-4" id="iconNavItems">
-            <li class="nav-item">
+            <li class="nav-item" style="position: relative;">
                 <a class="nav-link information" id="filters" data-bs-toggle="modal" data-bs-target="#filtersModal"></a>
+                <span id="filtersActiveIndicator" class="version-selected-dot"
+                    style="display: none; position: absolute; top: 4px; right: 4px;"></span>
             </li>
             <li class="nav-item">
                 <a class="nav-link information" id="customizeLayout"></a>

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -464,6 +464,7 @@
                                 </span>
                                 <div class="d-flex align-items-center">
                                     <select class="form-select form-select-sm" id="runs" style="width: 200px;"></select>
+                                    <span id="filterRunSelectedIndicator" class="filter-active-dot" style="display:none;"></span>
                                 </div>
                             </div>
                             <div class="list-group-item" id="runTagFilter">
@@ -850,11 +851,19 @@
                                         </div>
                                     </div>
                                     <div class="list-group-item d-flex justify-content-between align-items-center">
-                                        <span class="information info-label" id="settingPercentageFilters">Display Percentage Filters <span class="info-icon-small ms-1"></span></span>
-                                        <div class="form-check form-switch mb-0">
-                                            <input class="form-check-input" type="checkbox" role="switch"
-                                                id="switchPercentageFilters" />
-                                        </div>
+                                        <span class="information info-label" id="settingOverviewDurationPercentage">Duration comparison percentage <span class="info-icon-small ms-1"></span></span>
+                                        <select class="form-select form-select-sm" id="overviewDurationPercentage" style="width: auto;">
+                                            <option value="10">10%</option>
+                                            <option value="20">20%</option>
+                                            <option value="30">30%</option>
+                                            <option value="40">40%</option>
+                                            <option value="50">50%</option>
+                                            <option value="60">60%</option>
+                                            <option value="70">70%</option>
+                                            <option value="80">80%</option>
+                                            <option value="90">90%</option>
+                                            <option value="100">100%</option>
+                                        </select>
                                     </div>
                                     <div class="list-group-item d-flex justify-content-between align-items-center">
                                         <span class="information info-label" id="settingVersionFilters">Display Version Filters <span class="info-icon-small ms-1"></span></span>

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -461,10 +461,11 @@
                                 <span class="d-flex align-items-center information info-label" id="filterRunsInformation">
                                     Runs
                                     <span class="info-icon-small ms-1"></span>
+                                    <span id="filterRunSelectedIndicator" class="version-selected-dot ms-2 mt-1"
+                                        style="display: none;"></span>
                                 </span>
                                 <div class="d-flex align-items-center">
                                     <select class="form-select form-select-sm" id="runs" style="width: 200px;"></select>
-                                    <span id="filterRunSelectedIndicator" class="filter-active-dot" style="display:none;"></span>
                                 </div>
                             </div>
                             <div class="list-group-item" id="runTagFilter">


### PR DESCRIPTION
Implementation of #301 

Sorry for the one large commit, my IDE autoformatted a bunch of code, making diffs giant and I only realized it too late.
Do you care about atomic commits for review or do you review all changes in one diff anyway?

Changes made:
1. Filter button shown in overview
2. Filter applies in overview (accesses filteredRuns as datasource now)
3. Removed percentage select from overview, moved to global settings
4. moved overview subfilter functions filter.js -> overview.js (it is a filter, but has more to do with overview imo, let me know if I should revert it) 
5. minor bugfixes/guards
6. add filter active indicator to filter button

I dont know if you want the filter active dot in the topbar, just drop those commits if you dont,
I just added them since I frequently forgot if I had a filter active during testing.

Heres a sample:
[apply_overview_filter.html](https://github.com/user-attachments/files/29376351/apply_overview_filter.html)

I hope it isn't too much of a hassle to review :)
Please take your time and let me know if I should change anything.
Thank you!


